### PR TITLE
add config to kinect for filtering out the depth camera's wide FOV

### DIFF
--- a/config/kinect.lua
+++ b/config/kinect.lua
@@ -4,21 +4,23 @@ points_topic = "kinect_points";
 image_topic = "kinect_image";
 image_frame = "kinect";
 scan_frame = "base_link";
-scan_topic = "scan";
+scan_topic = "kinect_scan";
 
 rotation = {
-  yaw = 2;
-  pitch = 26;
-  roll = 2;
+  yaw = 0;
+  pitch = 17;
+  roll = 0;
 };
 
 translation = {
   x = 0;
   y = 0;
-  z = 0.45;
+  z = .60;
 };
 
 skip_points = 10;
-ground_dist_thresh = 0.02;
-ground_angle_thresh = 2.0; -- Degrees.
+ground_dist_thresh = 0.04;
+ground_angle_thresh = 5.0; -- Degrees.
+camera_angle_thresh = 55.0;
 num_ranges = 180;
+

--- a/src/depth_to_lidar.cc
+++ b/src/depth_to_lidar.cc
@@ -89,6 +89,7 @@ CONFIG_UINT(num_ranges, "num_ranges");
 
 CONFIG_FLOAT(ground_angle_thresh, "ground_angle_thresh");
 CONFIG_FLOAT(ground_dist_thresh, "ground_dist_thresh");
+CONFIG_FLOAT(camera_angle_thresh, "camera_angle_thresh");
 
 class DepthToLidar : public K4AWrapper {
  public:
@@ -235,6 +236,7 @@ class DepthToLidar : public K4AWrapper {
     static CumulativeFunctionTimer ft("Conversion");
     CumulativeFunctionTimer::Invocation invoke(&ft);
     const float tan_a = tan(DegToRad(CONFIG_ground_angle_thresh));
+    const float tan_ca = tan(DegToRad(CONFIG_camera_angle_thresh));
     const float angle_min = -M_PI_2;
     const float angle_max = M_PI_2;
     const int num_ranges = CONFIG_num_ranges;
@@ -246,7 +248,8 @@ class DepthToLidar : public K4AWrapper {
     for (int idx = 0; idx < num_pixels; idx += incr) {
       p = tf * (static_cast<float>(depth_data[idx]) * rgbd_ray_lookup_[idx]);
       if (fabs(p.z() / p.x()) < tan_a || 
-          fabs(p.z()) < CONFIG_ground_dist_thresh) continue;
+          fabs(p.z()) < CONFIG_ground_dist_thresh ||
+          fabs((p.z() - CONFIG_tz) / p.x()) > tan_ca) continue;
       const float a = atan2(p.y(), p.x());
       const float r = Vector2f(p.x(), p.y()).norm();
       const int index = (a - angle_min) / angle_increment;


### PR DESCRIPTION
The wide FOV of the kinect as mounted on the jackal caused it to detect parts of the robot as an obstacle.

This adds a config to k4a ros to allow the laser scan to filter out points that come from the wide-out regions of the depth-camera's FOV.