### PR TITLE
Publish IMU data from the SDK

### DIFF
--- a/config/kinect.lua
+++ b/config/kinect.lua
@@ -7,6 +7,7 @@ rgb_image_frame = "kinect_color";
 depth_image_frame = "kinect_depth";
 scan_frame = "base_link";
 scan_topic = "kinect_scan";
+imu_topic = "kinect_imu";
 registered_rgbd = true;
 
 rotation = {
@@ -27,4 +28,3 @@ ground_angle_thresh = 5.0; -- Degrees.
 camera_angle_thresh = 50.0;
 min_dist_thresh = 0.05;
 num_ranges = 180;
-

--- a/src/depth_to_lidar.cc
+++ b/src/depth_to_lidar.cc
@@ -342,7 +342,7 @@ class DepthToLidar : public K4AWrapper {
     uint64_t sec =
         boot_timestamp_.sec + imu_sample.acc_timestamp_usec / 1'000'000;
     uint64_t nsec = boot_timestamp_.nsec +
-                    imu_sample.acc_timestamp_usec % 1'000'000 * 1'000;
+                    (imu_sample.acc_timestamp_usec % 1'000'000) * 1'000;
 
     sec += nsec / 1'000'000'000;
     nsec %= 1'000'000'000;

--- a/src/depth_to_lidar.cc
+++ b/src/depth_to_lidar.cc
@@ -343,9 +343,10 @@ class DepthToLidar : public K4AWrapper {
     imu_msg_.angular_velocity.x = imu_sample.gyro_sample.xyz.x;
     imu_msg_.angular_velocity.y = imu_sample.gyro_sample.xyz.y;
     imu_msg_.angular_velocity.z = imu_sample.gyro_sample.xyz.z;
-    imu_msg_.linear_acceleration.x = imu_sample.acc_sample.xyz.x;
-    imu_msg_.linear_acceleration.y = imu_sample.acc_sample.xyz.y;
-    imu_msg_.linear_acceleration.z = imu_sample.acc_sample.xyz.z;
+    // Convert values to g = +9.8 m/s^2 convention
+    imu_msg_.linear_acceleration.x = -imu_sample.acc_sample.xyz.x;
+    imu_msg_.linear_acceleration.y = -imu_sample.acc_sample.xyz.y;
+    imu_msg_.linear_acceleration.z = -imu_sample.acc_sample.xyz.z;
 
     imu_publisher_.publish(imu_msg_);
   }

--- a/src/depth_to_lidar.cc
+++ b/src/depth_to_lidar.cc
@@ -35,6 +35,7 @@
 #include "ros/ros.h"
 #include "sensor_msgs/Image.h"
 #include "sensor_msgs/image_encodings.h"
+#include "sensor_msgs/Imu.h"
 #include "sensor_msgs/LaserScan.h"
 #include "sensor_msgs/PointCloud2.h"
 #include "sensor_msgs/point_cloud2_iterator.h"
@@ -63,6 +64,7 @@ DECLARE_int32(v);
 DEFINE_bool(depth, false, "Publish depth images");
 DEFINE_bool(points, false, "Publish point cloud");
 DEFINE_bool(rgb, false, "Publish color images");
+DEFINE_bool(imu, false, "Publish IMU data");
 DEFINE_string(config_file, "config/kinect.lua", "Name of config file to use");
 
 CONFIG_STRING(serial, "kinect_serial");
@@ -74,6 +76,7 @@ CONFIG_STRING(rgb_frame, "rgb_image_frame");
 CONFIG_STRING(depth_frame, "depth_image_frame");
 CONFIG_STRING(scan_topic, "scan_topic");
 CONFIG_STRING(scan_frame, "scan_frame");
+CONFIG_STRING(imu_topic, "imu_topic");
 CONFIG_BOOL(registered, "registered_rgbd");
 
 CONFIG_FLOAT(yaw, "rotation.yaw");
@@ -105,6 +108,8 @@ class DepthToLidar : public K4AWrapper {
         n.advertise<sensor_msgs::PointCloud2>(CONFIG_points_topic, 1, false);
     scan_publisher_ = 
         n.advertise<sensor_msgs::LaserScan>(CONFIG_scan_topic, 1, false);
+    imu_publisher_ =
+        n.advertise<sensor_msgs::Imu>(CONFIG_imu_topic, 1, false);
     rgb_publisher_ = image_transport_.advertise(CONFIG_rgb_topic, 1);
     depth_publisher_ = image_transport_.advertise(CONFIG_depth_topic, 1);
     InitMessages();
@@ -114,11 +119,13 @@ class DepthToLidar : public K4AWrapper {
   void InitMessages() {
     depth_msg_.header.seq = heightmap_msg_.header.seq = rgb_msg_.header.seq = 
         cloud_msg_.header.seq = scan_msg_.header.seq = 0;
+    imu_msg_.header.seq = 0;
     
     rgb_msg_.header.frame_id = CONFIG_rgb_frame;
     depth_msg_.header.frame_id = CONFIG_depth_frame;
     scan_msg_.header.frame_id = CONFIG_scan_frame;
     cloud_msg_.header.frame_id = CONFIG_scan_frame;
+    imu_msg_.header.frame_id = CONFIG_depth_frame;
 
     heightmap_msg_.header = scan_msg_.header;
     // OpenCV Image format, float, 2 channel.
@@ -170,6 +177,9 @@ class DepthToLidar : public K4AWrapper {
     cloud_msg_.data.resize(width * height * cloud_msg_.point_step);
     cloud_msg_.width = width;
     cloud_msg_.height = height;
+
+    // Signify that the orientation field should be ignored.
+    imu_msg_.orientation_covariance.fill(-1);
   }
 
   void InitLookups() {
@@ -321,6 +331,25 @@ class DepthToLidar : public K4AWrapper {
   void PublishHeightMap() {
   }
 
+  void ImuCallback(k4a_imu_sample_t& imu_sample) override {
+    if (!FLAGS_imu) {
+      return;
+    }
+
+    imu_msg_.header.stamp =
+        ros::Time(imu_sample.acc_timestamp_usec / 1'000'000,
+                  imu_sample.acc_timestamp_usec % 1'000'000 * 1'000);
+
+    imu_msg_.angular_velocity.x = imu_sample.gyro_sample.xyz.x;
+    imu_msg_.angular_velocity.y = imu_sample.gyro_sample.xyz.y;
+    imu_msg_.angular_velocity.z = imu_sample.gyro_sample.xyz.z;
+    imu_msg_.linear_acceleration.x = imu_sample.acc_sample.xyz.x;
+    imu_msg_.linear_acceleration.y = imu_sample.acc_sample.xyz.y;
+    imu_msg_.linear_acceleration.z = imu_sample.acc_sample.xyz.z;
+
+    imu_publisher_.publish(imu_msg_);
+  }
+
   void RGBDCallback(k4a_image_t color_image, k4a_image_t depth_image) {
     if (color_image != nullptr && FLAGS_rgb) {
       PublishRGBImage(color_image);
@@ -361,10 +390,12 @@ class DepthToLidar : public K4AWrapper {
   sensor_msgs::Image rgb_msg_;
   sensor_msgs::Image depth_msg_;
   sensor_msgs::Image heightmap_msg_;
+  sensor_msgs::Imu imu_msg_;
   sensor_msgs::PointCloud2 cloud_msg_;
   ros::Publisher costmap_publisher_;
   ros::Publisher cloud_publisher_;
   ros::Publisher scan_publisher_;
+  ros::Publisher imu_publisher_;
   image_transport::Publisher rgb_publisher_;
   image_transport::Publisher depth_publisher_;
   image_transport::Publisher heightmap_publisher_;
@@ -392,6 +423,3 @@ int main(int argc, char* argv[]) {
   }
   return 0;
 }
-
-
-

--- a/src/k4a_wrapper.cc
+++ b/src/k4a_wrapper.cc
@@ -146,6 +146,13 @@ void K4AWrapper::Capture() {
         if (color_image) k4a_image_release(color_image);
       }
       k4a_capture_release(capture);
+
+      // Process IMU sample queue
+      k4a_imu_sample_t imu_sample;
+      while (k4a_device_get_imu_sample(device_, &imu_sample, 0) ==
+             K4A_WAIT_RESULT_SUCCEEDED) {
+        ImuCallback(imu_sample);
+      }
     } break;
     case K4A_WAIT_RESULT_TIMEOUT: {
       printf("Timed out waiting for a capture\n");

--- a/src/k4a_wrapper.cc
+++ b/src/k4a_wrapper.cc
@@ -57,6 +57,10 @@ K4AWrapper::K4AWrapper(
     k4a_device_close(device_);
     abort();
   }
+  if (K4A_RESULT_SUCCEEDED != k4a_device_start_imu(device_)) {
+    k4a_device_close(device_);
+    abort();
+  }
 }
 
 K4AWrapper::~K4AWrapper() {

--- a/src/k4a_wrapper.h
+++ b/src/k4a_wrapper.h
@@ -41,6 +41,7 @@ class K4AWrapper {
       k4a_image_t image_rgb, k4a_image_t image_depth) {}
   virtual void RegisteredRGBDCallback(
       k4a_image_t image_rgb, k4a_image_t image_depth) {}
+  virtual void ImuCallback(k4a_imu_sample_t& imu_sample) {}
 
  private:
   void OpenDevice(const std::string& serial);


### PR DESCRIPTION
## Summary

Adds an additional command-line option (`--imu`) to `depth_to_lidar` to publish `sensor_msgs/Imu` from the onboard gyroscope and accelerometer.

## Details

The `angular_velocity` and `linear_acceleration` fields of `sensor_msgs/Imu` are populated directly from the gyroscope and accelerometer, respectively. Both `angular_velocity` and `linear_acceleration` use a right-handed coordinate system with a gravity-aligned Z-axis. (See [here][kinect-gyro-frame]) Linear acceleration due to gravity uses the positive 9.8 m/s^2 convention.

The `orientation` field is left blank since it cannot be calculated reliably when the robot is accelerating. However, downstream programs can use Rodrigues' rotation formula (using the unit Z vector and the unit acceleration vector) when the robot is stationary to estimate the rotation component of the camera extrinsic matrix.

The Kinect API maintains an internal queue of IMU readings. This PR follows [Microsoft's suggested polling scheme][access-imu-samples], processing outstanding IMU readings in the same thread that handles images.

[kinect-gyro-frame]: https://docs.microsoft.com/en-us/azure/kinect-dk/coordinate-systems#gyroscope-and-accelerometer
[access-imu-samples]: https://docs.microsoft.com/en-us/azure/kinect-dk/retrieve-imu-samples#access-imu-samples

## Real-World Tests

- [x] What is the publishing frequency?
  - On the beefy Spot laptop `rostopic echo` stabilizes between 350Hz and 600Hz.
- [x] Is a `ros::Publisher` queue size of 1 sufficient?
  - Yes
- [x] What is the runtime overhead of dequeueing the IMU messages queue?
  - On the Spot laptop, the entire `while (k4a_device_get_imu_sample...)` loop has a mean run time of < 0.5 ms as measured by `CumulativeFunctionTimer` when the `/kinect_imu` topic is being actively subscribed to and < 0.1 ms when the `--imu` flag is not provided.